### PR TITLE
add pigz by default and remove redundant wait call that can hang

### DIFF
--- a/doodad/darchive/archive_builder_docker.py
+++ b/doodad/darchive/archive_builder_docker.py
@@ -22,13 +22,9 @@ from doodad.utils import cmd_builder
 
 THIS_FILE_DIR = os.path.dirname(__file__)
 MAKESELF_PATH = os.path.join(THIS_FILE_DIR, 'makeself.sh')
-try:
-    # use pigz to parallelize if possible
-    p = subprocess.Popen(['pigz'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    p.communicate()
+MAKESELF_ARGS = ''
+if shutil.which('pigz') is not None:
     MAKESELF_ARGS = '--pigz'
-except FileNotFoundError:
-    MAKESELF_ARGS = ''
 MAKESELF_HEADER_PATH = os.path.join(THIS_FILE_DIR, 'makeself-header.sh')
 BEGIN_HEADER = '--- BEGIN DAR OUTPUT ---'
 DAR_PAYLOAD_MOUNT = 'dar_payload'


### PR DESCRIPTION
The call to `p.wait()` can [cause the program to hang](https://stackoverflow.com/questions/1445627/how-can-i-find-out-why-subprocess-popen-wait-waits-forever-if-stdout-pipe) if the output to the `makeself.sh` script is longer than the read buffer (4k).

This removes that call. I also added a speedup that uses `pigz` (if it's installed) to compress the DAR file faster.