### PR TITLE
Add MountRemote for custom mounts

### DIFF
--- a/doodad/__init__.py
+++ b/doodad/__init__.py
@@ -1,6 +1,6 @@
 from .launch.launch_api import run_command, run_python
 from .mode import LocalMode, SSHMode, GCPMode, AzureMode, EC2Mode, EC2Autoconfig
-from .mount import MountLocal, MountGit, MountGCP, MountAzure
+from .mount import MountLocal, MountGit, MountGCP, MountAzure, MountRemote
 
 __version__ = '1.0.0'
 

--- a/doodad/mount.py
+++ b/doodad/mount.py
@@ -269,6 +269,13 @@ class MountRemote(Mount):
     exist on whatever platform you're using."""
 
     def __init__(self, local_dir=None, output=True, **kwargs):
+        """Create a remote mount.
+
+        :param local_dir: a directory that you know will exist locally on the
+        running machine
+        :param output: same meaning as in `Mount`, but default to True.
+        :param kwargs: kwargs for `Mount`
+        """
         super(MountRemote, self).__init__(output=output, **kwargs)
         self._name = local_dir
         self.sync_dir = local_dir

--- a/doodad/mount.py
+++ b/doodad/mount.py
@@ -263,3 +263,18 @@ class MountAzure(Mount):
     def dar_extract_command(self):
         return 'echo helloMountAzure'
 
+
+class MountRemote(Mount):
+    """This is for mounting writable directories that you know will already
+    exist on whatever platform you're using."""
+
+    def __init__(self, local_dir=None, output=True, **kwargs):
+        super(MountRemote, self).__init__(output=output, **kwargs)
+        self._name = local_dir
+        self.sync_dir = local_dir
+
+    def dar_build_archive(self, deps_dir):
+        return
+
+    def dar_extract_command(self):
+        return 'echo helloMountRemote'

--- a/doodad/wrappers/easy_launch/config.py
+++ b/doodad/wrappers/easy_launch/config.py
@@ -8,6 +8,7 @@ NON_CODE_DIRS_TO_MOUNT = [
         mount_point='/root/.mujoco',
     ),
 ]
+REMOTE_DIRS_TO_MOUNT = []
 LOCAL_LOG_DIR = '/home/user/logs/'
 
 # see https://docs.microsoft.com/en-us/azure/virtual-machines/ncv3-series

--- a/doodad/wrappers/easy_launch/core.py
+++ b/doodad/wrappers/easy_launch/core.py
@@ -30,6 +30,7 @@ def sweep_function(
         extra_launch_info=None,
         code_dirs_to_mount=config.CODE_DIRS_TO_MOUNT,
         non_code_dirs_to_mount=config.NON_CODE_DIRS_TO_MOUNT,
+        remote_mount_configs=config.REMOTE_DIRS_TO_MOUNT,
         azure_region=config.DEFAULT_AZURE_REGION,
 ):
     """
@@ -94,6 +95,7 @@ def sweep_function(
         docker_image,
         code_dirs_to_mount=code_dirs_to_mount,
         non_code_dirs_to_mount=non_code_dirs_to_mount,
+        remote_mount_configs=remote_mount_configs,
         use_gpu=use_gpu,
     )
     git_infos = metadata.generate_git_infos()
@@ -215,10 +217,14 @@ def _run_method_here_no_doodad(
 def create_mounts(
         code_dirs_to_mount=config.CODE_DIRS_TO_MOUNT,
         non_code_dirs_to_mount=config.NON_CODE_DIRS_TO_MOUNT,
+        remote_mount_configs=config.REMOTE_DIRS_TO_MOUNT,
 ):
     non_code_mounts = [
         doodad.MountLocal(**non_code_mapping)
         for non_code_mapping in non_code_dirs_to_mount
+    ] + [
+        doodad.MountRemote(**non_code_mapping)
+        for non_code_mapping in remote_mount_configs
     ]
     if REPO_DIR not in config.CODE_DIRS_TO_MOUNT:
         config.CODE_DIRS_TO_MOUNT.append(REPO_DIR)
@@ -236,11 +242,13 @@ def create_sweeper_and_output_mount(
         docker_image,
         code_dirs_to_mount=config.CODE_DIRS_TO_MOUNT,
         non_code_dirs_to_mount=config.NON_CODE_DIRS_TO_MOUNT,
+        remote_mount_configs=config.REMOTE_DIRS_TO_MOUNT,
         use_gpu=False,
 ):
     mounts = create_mounts(
         code_dirs_to_mount=code_dirs_to_mount,
         non_code_dirs_to_mount=non_code_dirs_to_mount,
+        remote_mount_configs=remote_mount_configs,
     )
     az_mount = doodad.MountAzure(
         '',


### PR DESCRIPTION
Adding `MountRemote` for mounting writable directories that you know will already exist on whatever platform you're using. This is mainly for power-users. For example, I want to mount things from the Azure directory, but `MountAzure` is hard-coded to be an output-directory.