### PR TITLE
Increased priority of underutilized regions

### DIFF
--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -580,8 +580,8 @@ class AzureMode(LaunchMode):
             spot_price (float): Maximal price for preemptible instance. Specify -1 for the no limit price for the spot instance.
             **kwargs:
     """
-    US_REGIONS = ['eastus', 'westus2', 'eastus2', 'westus', 'centralus', 'northcentralus',
-                  'southcentralus', 'westcentralus']
+    US_REGIONS = ['eastus2', 'southcentralus', 'eastus', 'westus2', 'centralus', 'northcentralus',
+                  'westus', 'westcentralus']
     ABROAD_REGIONS = ['canadacentral', 'canadaeast', 'northeurope', 'ukwest', 'uksouth', 'westeurope', 'francecentral',
                       'switzerlandnorth', 'germanywestcentral', 'norwayeast', 'brazilsouth', 'eastasia',
                       'japanwest', 'japaneast', 'koreacentral', 'koreasouth', 'southeastasia',


### PR DESCRIPTION
This should improve the Azure VM launch speed (temporarily). We could include automatic quota availability check later to distribute the workload evenly.