### PR TITLE
Speed up gpu vm creation

### DIFF
--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -696,7 +696,7 @@ class AzureMode(LaunchMode):
         else:
             regions_to_try += self._retry_regions
         regions_to_try = _remove_duplicates(regions_to_try)
-        use_data_science_image = self.use_gpu and self.gpu_model == 'nvidia-tesla-v100'
+        use_data_science_image = self.use_gpu and (self.gpu_model == 'nvidia-tesla-v100' or self.gpu_model == 'nvidia-tesla-t4')
         install_nvidia_extension = self.use_gpu and not use_data_science_image
 
         first_try = True

--- a/scripts/azure/azure_startup_script.sh
+++ b/scripts/azure/azure_startup_script.sh
@@ -17,8 +17,8 @@ query_metadata() {
     remote_script_args='DOODAD_REMOTE_SCRIPT_ARGS'
     shell_interpreter=DOODAD_SHELL_INTERPRETER
     terminate_on_end=DOODAD_TERMINATE_ON_END
-    use_gpu=DOODAD_USE_GPU
     overwrite_logs=DOODAD_OVERWRITE_LOGS
+    install_nvidia_extension=DOODAD_INSTALL_NVIDIA_EXTENSION
 
     # Install docker following instructions from
     # https://docs.docker.com/engine/install/ubuntu/
@@ -93,7 +93,7 @@ query_metadata() {
     # https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest#sign-in-with-a-managed-identity
     az login --identity
 
-    if [ "$use_gpu" = "true" ]; then
+    if [ "$install_nvidia_extension" = "true" ]; then
         sudo apt install -y aptdaemon
         echo 'Installing nvidia extension'
           az vm extension set \


### PR DESCRIPTION
Speeds up the GPU VM set up time by using an image with preinstalled nvidia drivers . The VMs will now use 150GB disk instead of 30GB due to larger image size.